### PR TITLE
Match signature of syncback extension

### DIFF
--- a/syncback/Tiltfile
+++ b/syncback/Tiltfile
@@ -20,4 +20,4 @@ k8s_yaml('kubernetes.yaml')
 k8s_resource('example-rails', port_forwards=8000,
              resource_deps=['deploy'])
 
-syncback('syncback-rails', 'example-rails', ['Gemfile.lock', 'yarn.lock', 'app/', 'test/'])
+syncback('syncback-rails', 'example-rails', '/app/', paths=['Gemfile.lock', 'yarn.lock', 'app/', 'test/'])


### PR DESCRIPTION
- Required param `src_dir` was missing
- paths is now a named param

Corresponds to https://github.com/tilt-dev/tilt-extensions/blob/e4f91a1a7/syncback/Tiltfile