### PR TITLE
examples: update outdated dependencies to run projects

### DIFF
--- a/base/Gemfile.lock
+++ b/base/Gemfile.lock
@@ -93,7 +93,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -220,4 +222,4 @@ RUBY VERSION
    ruby 2.5.8p224
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/live-update/Dockerfile
+++ b/live-update/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5.8-alpine3.12
 
 #RUN apt-get update -qq && apt-get install -y nodejs npm
-RUN apk add --update build-base yarn sqlite-dev tzdata
+RUN apk add --update build-base yarn sqlite-dev tzdata shared-mime-info
 
 WORKDIR /app
 

--- a/live-update/Gemfile.lock
+++ b/live-update/Gemfile.lock
@@ -93,7 +93,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -220,4 +222,4 @@ RUBY VERSION
    ruby 2.5.8p224
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/syncback/Gemfile.lock
+++ b/syncback/Gemfile.lock
@@ -93,7 +93,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -220,4 +222,4 @@ RUBY VERSION
    ruby 2.5.8p224
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
The version of `mimemagic` this project was using is no longer available, meaning it wasn't possible to run these example projects. 

Note: I'm not able to run the `syncback` example because of an issue with `rsync`, so that's the only project I wasn't able to get back up and running to test.